### PR TITLE
Fix MANIFEST.in package name and add README badges

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include README.md
 include LICENSE
 include Makefile
 include pyproject.toml
-recursive-include ap_copy_lights *.py
+recursive-include ap_move_lights *.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # ap-move-lights
 
+[![Test](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/test.yml/badge.svg)](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/test.yml)
+[![Coverage](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/coverage.yml/badge.svg)](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/coverage.yml)
+[![Lint](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/lint.yml/badge.svg)](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/lint.yml)
+[![Format](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/format.yml/badge.svg)](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/format.yml)
+[![Typecheck](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/typecheck.yml/badge.svg)](https://github.com/jewzaam/ap-move-raw-light-to-blink/actions/workflows/typecheck.yml)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 A simple tool for moving and organizing astrophotography files from a raw directory to a destination directory, organizing them based on FITS header metadata.
 
 ## Overview


### PR DESCRIPTION
- Fix MANIFEST.in package reference from ap_copy_lights to ap_move_lights
- Add GitHub workflow badges for Test, Coverage, Lint, Format, and Typecheck
- Add Python 3.10+ version badge
- Add Black code style badge

Assisted-by: Claude Code (Claude Sonnet 4.5)