### PR TITLE
Enforce typecheck in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-verbose: install-dev
 	$(PYTHON) -m pytest -v
 
 typecheck: install-dev
-	$(PYTHON) -m mypy ap_move_raw_light_to_blink || true
+	$(PYTHON) -m mypy ap_move_raw_light_to_blink
 
 coverage: install-dev
 	$(PYTHON) -m pytest --cov=ap_move_raw_light_to_blink --cov-report=term


### PR DESCRIPTION
- Remove || true from typecheck target to enforce type checking

Assisted-by: Claude Code (Claude Sonnet 4.5)