### PR TITLE
Fix documentation reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This tool is part of the astrophotography pipeline. For comprehensive documentat
 
 - **[Pipeline Overview](https://github.com/jewzaam/ap-base/blob/main/docs/index.md)** - Full pipeline documentation
 - **[Workflow Guide](https://github.com/jewzaam/ap-base/blob/main/docs/workflow.md)** - Detailed workflow with diagrams
-- **[ap-common Reference](https://github.com/jewzaam/ap-base/blob/main/docs/tools/ap-common.md)** - API reference for this tool
+- **[ap-move-raw-light-to-blink Reference](https://github.com/jewzaam/ap-base/blob/main/docs/tools/ap-move-raw-light-to-blink.md)** - API reference for this tool
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Updated the README.md documentation reference link to point to the correct tool documentation page.

## Changes
- Changed the ap-common reference link to ap-move-raw-light-to-blink reference link
- Updated both the link text and URL to correctly reference the appropriate tool's API documentation

## Details
The README was incorrectly linking to generic "ap-common" documentation when it should have been linking to the specific "ap-move-raw-light-to-blink" tool documentation. This ensures users are directed to the correct API reference for this tool.

https://claude.ai/code/session_01VRUYV8bDntgm8VjiQkgEh3